### PR TITLE
Support BFT blocks in block browser

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,12 +7,15 @@ version '0.1-SNAPSHOT'
 
 repositories {
     mavenCentral()
-    maven {
-        url "https://hyperledger.jfrog.io/artifactory/besu-maven/"
-    }
+    maven { url "https://hyperledger.jfrog.io/hyperledger/besu-maven" }
+    maven { url "https://artifacts.consensys.net/public/maven/maven/" }
 }
 
 description("BEsu LAterna commandline interrogation tool")
+
+apply plugin: 'java'
+sourceCompatibility = 17
+targetCompatibility = 17
 
 dependencies {
     implementation 'org.hyperledger.besu.internal:core:22.4.0-RC2'
@@ -22,6 +25,9 @@ dependencies {
     implementation 'org.hyperledger.besu.internal:trie:22.4.0-RC2'
     implementation 'org.hyperledger.besu:besu-datatypes:22.4.0-RC2'
     implementation 'org.hyperledger.besu.internal:rlp:22.4.0-RC2'
+    implementation 'org.hyperledger.besu.internal:common:22.4.0-RC2'
+    implementation 'org.hyperledger.besu.internal:qbft:22.4.0-RC2'
+    implementation 'org.hyperledger.besu.internal:ibft:22.4.0-RC2'
     implementation 'org.hyperledger.besu:evm:22.4.0-RC2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.2'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/hyperledger/bela/ConsensusDetector.java
+++ b/src/main/java/org/hyperledger/bela/ConsensusDetector.java
@@ -1,0 +1,49 @@
+package org.hyperledger.bela;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.consensus.ibft.IbftExtraDataCodec;
+import org.hyperledger.besu.consensus.qbft.QbftExtraDataCodec;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
+import org.hyperledger.besu.ethereum.rlp.RLPException;
+import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStoragePrefixedKeyBlockchainStorage;
+import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
+
+public class ConsensusDetector {
+  public enum CONSENSUS_TYPE { ETH_HASH, IBFT2, QBFT }
+
+  public static CONSENSUS_TYPE detectConsensusMechanism(final KeyValueStorage keyValueStorage) {
+    var storage = new KeyValueStoragePrefixedKeyBlockchainStorage(keyValueStorage, new MainnetBlockHeaderFunctions());
+    var genesisHash = storage.getBlockHash(BlockHeader.GENESIS_BLOCK_NUMBER).orElseThrow();
+    var genesisBlockHeader = storage.getBlockHeader(genesisHash).orElseThrow();
+    var extraData = genesisBlockHeader.getExtraData();
+
+    if (isIbft2ExtraData(extraData)) {
+      return CONSENSUS_TYPE.IBFT2;
+    } else if (isQbftExtraData(extraData)) {
+      return CONSENSUS_TYPE.QBFT;
+    } else {
+      return CONSENSUS_TYPE.ETH_HASH;
+    }
+  }
+
+  private static boolean isIbft2ExtraData(final Bytes extraData) {
+    try {
+      new IbftExtraDataCodec().decodeRaw(extraData);
+      return true;
+    } catch (RLPException e) {
+      return false;
+    }
+  }
+
+  private static boolean isQbftExtraData(final Bytes extraData) {
+    try {
+      new QbftExtraDataCodec().decodeRaw(extraData);
+      return true;
+    } catch (RLPException e) {
+      return false;
+    }
+  }
+
+
+}


### PR DESCRIPTION
Add support for IBFT2 and QBFT blocks in the block browser.

QBFT and IBFT2 calculate the hash differently so need to detect what consensus mechanism is being used and pass through the appropriate hashing function.