### PR TITLE
change base docker image 

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk
+FROM openjdk:17-slim-bullseye
 
 EXPOSE 30303
 


### PR DESCRIPTION
to one that by default has all the *nix environment to support bela shell script, esp xargs



Signed-off-by: garyschulte <garyschulte@gmail.com>