### PR TITLE
Parallel BonsaiTraversal - 12x improvement

### DIFF
--- a/src/main/java/org/hyperledger/bela/utils/bonsai/BonsaiTraversal.java
+++ b/src/main/java/org/hyperledger/bela/utils/bonsai/BonsaiTraversal.java
@@ -80,7 +80,7 @@ public class BonsaiTraversal {
 
         final List<Node<Bytes>> nodes =
                 TrieNodeDecoder.decodeNodes(parentNode.getLocation().orElseThrow(), parentNode.getEncodedBytes());
-        nodes.forEach(
+        nodes.stream().parallel().forEach(
                 node -> {
                     // node is a branch node
                     if (nodeIsHashReferencedDescendant(parentNode, node)) {
@@ -149,7 +149,7 @@ public class BonsaiTraversal {
 
         final List<Node<Bytes>> nodes =
                 TrieNodeDecoder.decodeNodes(parentNode.getLocation().orElseThrow(), parentNode.getEncodedBytes());
-        nodes.forEach(
+        nodes.stream().parallel().forEach(
                 node -> {
                     if (nodeIsHashReferencedDescendant(parentNode, node)) {
                         traverseStorageTrie(

--- a/src/main/java/org/hyperledger/bela/utils/bonsai/BonsaiTreeVerifier.java
+++ b/src/main/java/org/hyperledger/bela/utils/bonsai/BonsaiTreeVerifier.java
@@ -22,7 +22,9 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -39,12 +41,25 @@ import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksD
 
 public class BonsaiTreeVerifier implements BonsaiListener {
 
-    private final AtomicInteger visited = new AtomicInteger(0);
+    private static boolean VERBOSE = false;
+    private final AtomicLong visited = new AtomicLong(0);
     private static final AtomicInteger errorCount = new AtomicInteger(0);
 
+    /*
+        ./bonsaitreeverifier /data/besu --verbose
+     */
     public static void main(final String[] args) {
         Instant start = Instant.now();
         final Path dataDir = Paths.get(args[0]);
+        String verboseArg = args.length > 1 ? args[1] : "";
+        if (verboseArg.startsWith("--verbose") || verboseArg.startsWith("-v")) {
+            System.out.println("Verbose mode enabled, tree traversal progress will be printed");
+            VERBOSE = true;
+        } else {
+            System.out.println("Verbose mode disabled, tree traversal progress will not be printed but errors will.");
+            System.out.println("Enable verbose mode with -v or --verbose as the second argument");
+        }
+        System.out.println();
         System.out.println("We are verifying : " + dataDir);
         final StorageProvider provider =
                 createKeyValueStorageProvider(dataDir, dataDir.resolve("database"));
@@ -73,12 +88,12 @@ public class BonsaiTreeVerifier implements BonsaiListener {
             e.printStackTrace();
         }
 
-        System.out.println("AAAAAAAAAA!!!!!!!");
+        System.out.println();
         Duration duration = Duration.between(start, Instant.now());
         System.out.printf("Duration: %d hours, %d minutes, %d seconds%n", duration.toHoursPart(), duration.toMinutesPart(), duration.toSecondsPart());
     }
 
-    private int getVisited() {
+    private long getVisited() {
         return visited.get();
     }
 
@@ -129,13 +144,15 @@ public class BonsaiTreeVerifier implements BonsaiListener {
 
     @Override
     public void visited(final BonsaiTraversalTrieType type) {
-        visited.incrementAndGet();
-        if (visited.get() % 10000 == 0) {
-            System.out.print(type.getText());
-        }
-        if (visited.get() % 1000000 == 0) {
-            System.out.println();
-            System.out.println("So far processed " + visited.get() + " nodes");
+        long currentVisited = visited.incrementAndGet();
+        if (VERBOSE) {
+            if (currentVisited % 10000 == 0) {
+                System.out.print(type.getText());
+            }
+            if (currentVisited % 1000000 == 0) {
+                System.out.println();
+                System.out.println("So far processed " + visited.get() + " nodes");
+            }
         }
     }
 

--- a/src/main/java/org/hyperledger/bela/utils/bonsai/BonsaiTreeVerifier.java
+++ b/src/main/java/org/hyperledger/bela/utils/bonsai/BonsaiTreeVerifier.java
@@ -79,7 +79,11 @@ public class BonsaiTreeVerifier implements BonsaiListener {
 
         System.out.println();
         Duration duration = Duration.between(start, Instant.now());
-        System.out.printf("Duration: %d hours, %d minutes, %d seconds%n", duration.toHoursPart(), duration.toMinutesPart(), duration.toSecondsPart());
+        double nodesPerMillisecond = (double) listener.getVisited() / duration.toMillis();
+        double nodesPerSecond = nodesPerMillisecond * 1000;
+        System.out.printf("Duration: %d hours, %d minutes, %d seconds (%d nodes per second)%n",
+                duration.toHoursPart(), duration.toMinutesPart(), duration.toSecondsPart(),
+                (int) nodesPerSecond);
     }
 
     private long getVisited() {

--- a/src/main/java/org/hyperledger/bela/utils/bonsai/BonsaiTreeVerifier.java
+++ b/src/main/java/org/hyperledger/bela/utils/bonsai/BonsaiTreeVerifier.java
@@ -22,7 +22,6 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -41,25 +40,15 @@ import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksD
 
 public class BonsaiTreeVerifier implements BonsaiListener {
 
-    private static boolean VERBOSE = false;
     private final AtomicLong visited = new AtomicLong(0);
     private static final AtomicInteger errorCount = new AtomicInteger(0);
 
     /*
-        ./bonsaitreeverifier /data/besu --verbose
+        ./bonsaitreeverifier /data/besu
      */
     public static void main(final String[] args) {
         Instant start = Instant.now();
         final Path dataDir = Paths.get(args[0]);
-        String verboseArg = args.length > 1 ? args[1] : "";
-        if (verboseArg.startsWith("--verbose") || verboseArg.startsWith("-v")) {
-            System.out.println("Verbose mode enabled, tree traversal progress will be printed");
-            VERBOSE = true;
-        } else {
-            System.out.println("Verbose mode disabled, tree traversal progress will not be printed but errors will.");
-            System.out.println("Enable verbose mode with -v or --verbose as the second argument");
-        }
-        System.out.println();
         System.out.println("We are verifying : " + dataDir);
         final StorageProvider provider =
                 createKeyValueStorageProvider(dataDir, dataDir.resolve("database"));
@@ -145,14 +134,12 @@ public class BonsaiTreeVerifier implements BonsaiListener {
     @Override
     public void visited(final BonsaiTraversalTrieType type) {
         long currentVisited = visited.incrementAndGet();
-        if (VERBOSE) {
-            if (currentVisited % 10000 == 0) {
-                System.out.print(type.getText());
-            }
-            if (currentVisited % 1000000 == 0) {
-                System.out.println();
-                System.out.println("So far processed " + visited.get() + " nodes");
-            }
+        if (currentVisited % 10000 == 0) {
+            System.out.print(type.getText());
+        }
+        if (currentVisited % 1000000 == 0) {
+            System.out.println();
+            System.out.println("So far processed " + visited.get() + " nodes");
         }
     }
 

--- a/src/main/java/org/hyperledger/bela/utils/bonsai/BonsaiTreeVerifier.java
+++ b/src/main/java/org/hyperledger/bela/utils/bonsai/BonsaiTreeVerifier.java
@@ -139,7 +139,7 @@ public class BonsaiTreeVerifier implements BonsaiListener {
         }
         if (currentVisited % 1000000 == 0) {
             System.out.println();
-            System.out.println("So far processed " + visited.get() + " nodes");
+            System.out.println("So far processed " + currentVisited + " nodes");
         }
     }
 

--- a/src/main/java/org/hyperledger/bela/utils/bonsai/BonsaiTreeVerifier.java
+++ b/src/main/java/org/hyperledger/bela/utils/bonsai/BonsaiTreeVerifier.java
@@ -39,7 +39,7 @@ import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksD
 
 public class BonsaiTreeVerifier implements BonsaiListener {
 
-    private int visited;
+    private final AtomicInteger visited = new AtomicInteger(0);
     private static final AtomicInteger errorCount = new AtomicInteger(0);
 
     public static void main(final String[] args) {
@@ -79,7 +79,7 @@ public class BonsaiTreeVerifier implements BonsaiListener {
     }
 
     private int getVisited() {
-        return visited;
+        return visited.get();
     }
 
     private static StorageProvider createKeyValueStorageProvider(
@@ -129,13 +129,13 @@ public class BonsaiTreeVerifier implements BonsaiListener {
 
     @Override
     public void visited(final BonsaiTraversalTrieType type) {
-        visited++;
-        if (visited % 10000 == 0) {
+        visited.incrementAndGet();
+        if (visited.get() % 10000 == 0) {
             System.out.print(type.getText());
         }
-        if (visited % 1000000 == 0) {
+        if (visited.get() % 1000000 == 0) {
             System.out.println();
-            System.out.println("So far processed " + visited + " nodes");
+            System.out.println("So far processed " + visited.get() + " nodes");
         }
     }
 

--- a/src/main/java/org/hyperledger/bela/windows/BonsaiTreeVerifierWindow.java
+++ b/src/main/java/org/hyperledger/bela/windows/BonsaiTreeVerifierWindow.java
@@ -4,6 +4,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import com.googlecode.lanterna.TerminalSize;
 import com.googlecode.lanterna.gui2.Label;
@@ -39,7 +40,7 @@ public class BonsaiTreeVerifierWindow extends AbstractBelaWindow implements Bons
     private final Label counterLabel = new Label("0");
     private final TextBox logTextBox = new TextBox(new TerminalSize(120, 30));
     private final AtomicReference<BonsaiTraversal> bonsaiTraversal = new AtomicReference<>();
-    AtomicInteger visited = new AtomicInteger(0);
+    AtomicLong visited = new AtomicLong(0);
     private Future<?> execution;
 
     public BonsaiTreeVerifierWindow(final WindowBasedTextGUI gui, final StorageProviderFactory storageProviderFactory) {


### PR DESCRIPTION
BonsaiTreeVerifier tree traversal is read-only, so it lends itself well to a naive parallel implementation using parallelStream for the child nodes.

12x improvment on holesky (with both besu and teku services stopped)
```
simon.dudley@dev-elc-bu-tk-holesky-simon-parallel-bvt:~/bela$ tail -f /data/bela.log

World state was successfully verified...
Verified root 0x520e9d1657af66a141329a593dca05cddb747edf47774c3cebe2868ccbde356c with 214630272 nodes

Duration: 0 hours, 13 minutes, 48 seconds (259016 nodes per second)
```

Previously holesky took nearly 3 hours...
```
simon.dudley@dev-elc-bu-tk-holesky-simon-parallel-bvt-ctrl:~/bela$ tail -f /data/bela.log

World state was successfully verified...
Verified root 0xf11bc6746bcb30553a7fd2d2cfd9d3ee3277c0845e5832e7d00018e5fb6bf18c with 214633626 nodes
AAAAAAAAAA!!!!!!!
Duration: 2 hours, 52 minutes, 27 seconds
```

Mainnet has ~10x more nodes than holesky so expect **mainnet to take ~2.5 hours**


e.g. mainnet has 2104544043 nodes
2104544043 / 259016 nodes per second / 3600 = 2.23 hours