### PR TITLE
Initial cut updating bela to 24.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,9 @@ apply plugin: 'java'
 sourceCompatibility = 21
 targetCompatibility = 21
 
-// specify the besu version to use via -PbesuVersion=.. otherwise default to 23.7.2.
+// specify the besu version to use via -PbesuVersion=.. otherwise default to 23.8.0.
 //   e.g. `-PbesuVersion=23.0.1-beta`
-def besuVersion = project.hasProperty('besuVersion') ? project.property('besuVersion') : '23.7.2'
+def besuVersion = project.hasProperty('besuVersion') ? project.property('besuVersion') : '24.8.0'
 
 def dockerOrgName = project.hasProperty('dockerOrgName') ? project.getProperty("dockerOrgName") : "consensys"
 def dockerArtifactName = project.hasProperty("dockerArtifactName") ? project.getProperty("dockerArtifactName") : "bela"

--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,9 @@ apply plugin: 'java'
 sourceCompatibility = 21
 targetCompatibility = 21
 
-// specify the besu version to use via -PbesuVersion=.. otherwise default to 23.8.0.
-//   e.g. `-PbesuVersion=23.0.1-beta`
-def besuVersion = project.hasProperty('besuVersion') ? project.property('besuVersion') : '24.8.0'
+// specify the besu version to use via -PbesuVersion=.. otherwise default to latest.
+//   e.g. `-PbesuVersion=24.9.1-RC1`
+def besuVersion = project.hasProperty('besuVersion') ? project.property('besuVersion') : '+'
 
 def dockerOrgName = project.hasProperty('dockerOrgName') ? project.getProperty("dockerOrgName") : "consensys"
 def dockerArtifactName = project.hasProperty("dockerArtifactName") ? project.getProperty("dockerArtifactName") : "bela"

--- a/latest-multi-arch.yaml
+++ b/latest-multi-arch.yaml
@@ -1,0 +1,10 @@
+image: suburbandad/bela:latest
+manifests:
+  - image: suburbandad/bela:latest-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: suburbandad/bela:latest-arm64
+    platform:
+      architecture: arm64
+      os: linux

--- a/multi-arch-docker.yaml
+++ b/multi-arch-docker.yaml
@@ -1,0 +1,10 @@
+image: suburbandad/bela:24.8.0
+manifests:
+  - image: suburbandad/bela:24.8.0-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: suburbandad/bela:24.8.0-arm64
+    platform:
+      architecture: arm64
+      os: linux

--- a/src/main/java/org/hyperledger/bela/components/bonsai/AddressStorageNode.java
+++ b/src/main/java/org/hyperledger/bela/components/bonsai/AddressStorageNode.java
@@ -12,13 +12,13 @@ import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.StorageSlotKey;
-import org.hyperledger.besu.ethereum.bonsai.BonsaiValue;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.DiffBasedValue;
 
 public class AddressStorageNode extends AbstractBonsaiNode {
-  private final Map<StorageSlotKey, BonsaiValue<UInt256>> tree;
+  private final Map<StorageSlotKey, DiffBasedValue<UInt256>> tree;
   private final Address address;
 
-  public AddressStorageNode(final Address address, Map<StorageSlotKey, BonsaiValue<UInt256>> tree) {
+  public AddressStorageNode(final Address address, Map<StorageSlotKey, DiffBasedValue<UInt256>> tree) {
     super(address.toHexString());
     this.address = address;
     this.tree = tree;

--- a/src/main/java/org/hyperledger/bela/components/bonsai/BelaKeyValueBlockchainStorage.java
+++ b/src/main/java/org/hyperledger/bela/components/bonsai/BelaKeyValueBlockchainStorage.java
@@ -1,0 +1,328 @@
+package org.hyperledger.bela.components.bonsai;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.chain.BlockchainStorage;
+import org.hyperledger.besu.ethereum.chain.TransactionLocation;
+import org.hyperledger.besu.ethereum.chain.VariablesStorage;
+import org.hyperledger.besu.ethereum.chain.VariablesStorage.Keys;
+import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.BlockHeaderFunctions;
+import org.hyperledger.besu.ethereum.core.Difficulty;
+import org.hyperledger.besu.ethereum.core.TransactionReceipt;
+import org.hyperledger.besu.ethereum.rlp.RLP;
+import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
+import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * TODO: Remove me.
+ * This class is temporary until changes in besu to KeyValueStoragePrefixedKeyBlockchainStorage
+ * make it optional to migrate variable storage, to support "read only" opening of besu databases.
+ */
+public class BelaKeyValueBlockchainStorage implements BlockchainStorage {
+  private static final Logger LOG = LoggerFactory.getLogger(
+      org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStoragePrefixedKeyBlockchainStorage.class);
+
+  private static final Bytes VARIABLES_PREFIX = Bytes.of(1);
+  private static final Bytes BLOCK_HEADER_PREFIX = Bytes.of(2);
+  private static final Bytes BLOCK_BODY_PREFIX = Bytes.of(3);
+  private static final Bytes TRANSACTION_RECEIPTS_PREFIX = Bytes.of(4);
+  private static final Bytes BLOCK_HASH_PREFIX = Bytes.of(5);
+  private static final Bytes TOTAL_DIFFICULTY_PREFIX = Bytes.of(6);
+  private static final Bytes TRANSACTION_LOCATION_PREFIX = Bytes.of(7);
+  final KeyValueStorage blockchainStorage;
+  final VariablesStorage variablesStorage;
+  final BlockHeaderFunctions blockHeaderFunctions;
+  final boolean receiptCompaction;
+
+  public BelaKeyValueBlockchainStorage(KeyValueStorage blockchainStorage,
+      VariablesStorage variablesStorage, BlockHeaderFunctions blockHeaderFunctions,
+      boolean receiptCompaction) {
+    this.blockchainStorage = blockchainStorage;
+    this.variablesStorage = variablesStorage;
+    this.blockHeaderFunctions = blockHeaderFunctions;
+    this.receiptCompaction = receiptCompaction;
+  }
+
+  public Optional<Hash> getChainHead() {
+    return this.variablesStorage.getChainHead();
+  }
+
+  public Collection<Hash> getForkHeads() {
+    return this.variablesStorage.getForkHeads();
+  }
+
+  public Optional<Hash> getFinalized() {
+    return this.variablesStorage.getFinalized();
+  }
+
+  public Optional<Hash> getSafeBlock() {
+    return this.variablesStorage.getSafeBlock();
+  }
+
+  public Optional<BlockHeader> getBlockHeader(Hash blockHash) {
+    return this
+        .get(BLOCK_HEADER_PREFIX, blockHash)
+        .map((b) -> BlockHeader.readFrom(RLP.input(b), this.blockHeaderFunctions));
+  }
+
+  public Optional<BlockBody> getBlockBody(Hash blockHash) {
+    return this
+        .get(BLOCK_BODY_PREFIX, blockHash)
+        .map((bytes) -> BlockBody.readWrappedBodyFrom(RLP.input(bytes), this.blockHeaderFunctions));
+  }
+
+  public Optional<List<TransactionReceipt>> getTransactionReceipts(Hash blockHash) {
+    return this.get(TRANSACTION_RECEIPTS_PREFIX, blockHash).map(this::rlpDecodeTransactionReceipts);
+  }
+
+  public Optional<Hash> getBlockHash(long blockNumber) {
+    return this.get(BLOCK_HASH_PREFIX, UInt256.valueOf(blockNumber)).map(this::bytesToHash);
+  }
+
+  public Optional<Difficulty> getTotalDifficulty(Hash blockHash) {
+    return this
+        .get(TOTAL_DIFFICULTY_PREFIX, blockHash)
+        .map((b) -> Difficulty.wrap(Bytes32.wrap(b, 0)));
+  }
+
+  public Optional<TransactionLocation> getTransactionLocation(Hash transactionHash) {
+    return this
+        .get(TRANSACTION_LOCATION_PREFIX, transactionHash)
+        .map((bytes) -> TransactionLocation.readFrom(RLP.input(bytes)));
+  }
+
+  public Updater updater() {
+    return new Updater(this.blockchainStorage.startTransaction(), this.variablesStorage.updater(),
+        this.receiptCompaction);
+  }
+
+  private List<TransactionReceipt> rlpDecodeTransactionReceipts(Bytes bytes) {
+    return RLP.input(bytes).readList(TransactionReceipt::readFrom);
+  }
+
+  private Hash bytesToHash(Bytes bytes) {
+    return Hash.wrap(Bytes32.wrap(bytes, 0));
+  }
+
+  Optional<Bytes> get(Bytes prefix, Bytes key) {
+    return this.blockchainStorage
+        .get(Bytes.concatenate(new Bytes[] {prefix, key}).toArrayUnsafe())
+        .map(Bytes::wrap);
+  }
+
+  public void migrateVariables() {
+    Updater blockchainUpdater = this.updater();
+    VariablesStorage.Updater variablesUpdater = this.variablesStorage.updater();
+    this
+        .get(VARIABLES_PREFIX, Keys.CHAIN_HEAD_HASH.getBytes())
+        .map(this::bytesToHash)
+        .ifPresent((bch) -> {
+          this.variablesStorage.getChainHead().ifPresentOrElse((vch) -> {
+            if (!vch.equals(bch)) {
+              logInconsistencyAndFail(Keys.CHAIN_HEAD_HASH, bch, vch);
+            }
+
+          }, () -> {
+            variablesUpdater.setChainHead(bch);
+            LOG.info("Migrated key {} to variables storage", Keys.CHAIN_HEAD_HASH);
+          });
+        });
+    this
+        .get(VARIABLES_PREFIX, Keys.FINALIZED_BLOCK_HASH.getBytes())
+        .map(this::bytesToHash)
+        .ifPresent((bfh) -> {
+          this.variablesStorage.getFinalized().ifPresentOrElse((vfh) -> {
+            if (!vfh.equals(bfh)) {
+              logInconsistencyAndFail(Keys.FINALIZED_BLOCK_HASH, bfh, vfh);
+            }
+
+          }, () -> {
+            variablesUpdater.setFinalized(bfh);
+            LOG.info("Migrated key {} to variables storage", Keys.FINALIZED_BLOCK_HASH);
+          });
+        });
+    this
+        .get(VARIABLES_PREFIX, Keys.SAFE_BLOCK_HASH.getBytes())
+        .map(this::bytesToHash)
+        .ifPresent((bsh) -> {
+          this.variablesStorage.getSafeBlock().ifPresentOrElse((vsh) -> {
+            if (!vsh.equals(bsh)) {
+              logInconsistencyAndFail(Keys.SAFE_BLOCK_HASH, bsh, vsh);
+            }
+
+          }, () -> {
+            variablesUpdater.setSafeBlock(bsh);
+            LOG.info("Migrated key {} to variables storage", Keys.SAFE_BLOCK_HASH);
+          });
+        });
+    this
+        .get(VARIABLES_PREFIX, Keys.FORK_HEADS.getBytes())
+        .map((bytes) -> RLP.input(bytes).readList((in) -> this.bytesToHash(in.readBytes32())))
+        .ifPresent((bfh) -> {
+          Collection<Hash> vfh = this.variablesStorage.getForkHeads();
+          if (vfh.isEmpty()) {
+            variablesUpdater.setForkHeads(bfh);
+            LOG.info("Migrated key {} to variables storage", Keys.FORK_HEADS);
+          } else if (!List.copyOf(vfh).equals(bfh)) {
+            logInconsistencyAndFail(Keys.FORK_HEADS, bfh, vfh);
+          }
+
+        });
+    this.get(Bytes.EMPTY, Keys.SEQ_NO_STORE.getBytes()).ifPresent((bsns) -> {
+      this.variablesStorage.getLocalEnrSeqno().ifPresentOrElse((vsns) -> {
+        if (!vsns.equals(bsns)) {
+          logInconsistencyAndFail(Keys.SEQ_NO_STORE, bsns, vsns);
+        }
+
+      }, () -> {
+        variablesUpdater.setLocalEnrSeqno(bsns);
+        LOG.info("Migrated key {} to variables storage", Keys.SEQ_NO_STORE);
+      });
+    });
+    blockchainUpdater.removeVariables();
+    variablesUpdater.commit();
+    blockchainUpdater.commit();
+  }
+
+  private static void logInconsistencyAndFail(VariablesStorage.Keys key, Object bch, Object vch) {
+    LOG.error(
+        "Inconsistency found when migrating {} to variables storage, probably this is due to a downgrade done without running the `storage revert-variables` subcommand first, see https://github.com/hyperledger/besu/pull/5471",
+        key);
+    String var10002 = String.valueOf(key);
+    throw new IllegalStateException(
+        var10002 + " mismatch: blockchain storage value=" + String.valueOf(
+            bch) + ", variables storage value=" + String.valueOf(vch));
+  }
+
+  public static class Updater implements BlockchainStorage.Updater {
+    private final KeyValueStorageTransaction blockchainTransaction;
+    private final VariablesStorage.Updater variablesUpdater;
+    private final boolean receiptCompaction;
+
+    Updater(KeyValueStorageTransaction blockchainTransaction,
+        VariablesStorage.Updater variablesUpdater, boolean receiptCompaction) {
+      this.blockchainTransaction = blockchainTransaction;
+      this.variablesUpdater = variablesUpdater;
+      this.receiptCompaction = receiptCompaction;
+    }
+
+    public void putBlockHeader(Hash blockHash, BlockHeader blockHeader) {
+      Bytes var10001 = BLOCK_HEADER_PREFIX;
+      Objects.requireNonNull(blockHeader);
+      this.set(var10001, blockHash, RLP.encode(blockHeader::writeTo));
+    }
+
+    public void putBlockBody(Hash blockHash, BlockBody blockBody) {
+      Bytes var10001 = BLOCK_BODY_PREFIX;
+      Objects.requireNonNull(blockBody);
+      this.set(var10001, blockHash, RLP.encode(blockBody::writeWrappedBodyTo));
+    }
+
+    public void putTransactionLocation(Hash transactionHash,
+        TransactionLocation transactionLocation) {
+      Bytes var10001 = TRANSACTION_LOCATION_PREFIX;
+      Objects.requireNonNull(transactionLocation);
+      this.set(var10001, transactionHash, RLP.encode(transactionLocation::writeTo));
+    }
+
+    public void putTransactionReceipts(Hash blockHash,
+        List<TransactionReceipt> transactionReceipts) {
+      this.set(TRANSACTION_RECEIPTS_PREFIX, blockHash, this.rlpEncode(transactionReceipts));
+    }
+
+    public void putBlockHash(long blockNumber, Hash blockHash) {
+      this.set(BLOCK_HASH_PREFIX, UInt256.valueOf(blockNumber), blockHash);
+    }
+
+    public void putTotalDifficulty(Hash blockHash, Difficulty totalDifficulty) {
+      this.set(TOTAL_DIFFICULTY_PREFIX, blockHash, totalDifficulty);
+    }
+
+    public void setChainHead(Hash blockHash) {
+      this.variablesUpdater.setChainHead(blockHash);
+    }
+
+    public void setForkHeads(Collection<Hash> forkHeadHashes) {
+      this.variablesUpdater.setForkHeads(forkHeadHashes);
+    }
+
+    public void setFinalized(Hash blockHash) {
+      this.variablesUpdater.setFinalized(blockHash);
+    }
+
+    public void setSafeBlock(Hash blockHash) {
+      this.variablesUpdater.setSafeBlock(blockHash);
+    }
+
+    public void removeBlockHash(long blockNumber) {
+      this.remove(BLOCK_HASH_PREFIX, UInt256.valueOf(blockNumber));
+    }
+
+    public void removeBlockHeader(Hash blockHash) {
+      this.remove(BLOCK_HEADER_PREFIX, blockHash);
+    }
+
+    public void removeBlockBody(Hash blockHash) {
+      this.remove(BLOCK_BODY_PREFIX, blockHash);
+    }
+
+    public void removeTransactionReceipts(Hash blockHash) {
+      this.remove(TRANSACTION_RECEIPTS_PREFIX, blockHash);
+    }
+
+    public void removeTransactionLocation(Hash transactionHash) {
+      this.remove(TRANSACTION_LOCATION_PREFIX, transactionHash);
+    }
+
+    public void removeTotalDifficulty(Hash blockHash) {
+      this.remove(TOTAL_DIFFICULTY_PREFIX, blockHash);
+    }
+
+    public void commit() {
+      this.blockchainTransaction.commit();
+      this.variablesUpdater.commit();
+    }
+
+    public void rollback() {
+      this.variablesUpdater.rollback();
+      this.blockchainTransaction.rollback();
+    }
+
+    void set(Bytes prefix, Bytes key, Bytes value) {
+      this.blockchainTransaction.put(Bytes.concatenate(new Bytes[] {prefix, key}).toArrayUnsafe(),
+          value.toArrayUnsafe());
+    }
+
+    private void remove(Bytes prefix, Bytes key) {
+      this.blockchainTransaction.remove(
+          Bytes.concatenate(new Bytes[] {prefix, key}).toArrayUnsafe());
+    }
+
+    private Bytes rlpEncode(List<TransactionReceipt> receipts) {
+      return RLP.encode((o) -> {
+        o.writeList(receipts, (r, rlpOutput) -> {
+          r.writeToForStorage(rlpOutput, this.receiptCompaction);
+        });
+      });
+    }
+
+    private void removeVariables() {
+      this.remove(VARIABLES_PREFIX, Keys.CHAIN_HEAD_HASH.getBytes());
+      this.remove(VARIABLES_PREFIX, Keys.FINALIZED_BLOCK_HASH.getBytes());
+      this.remove(VARIABLES_PREFIX, Keys.SAFE_BLOCK_HASH.getBytes());
+      this.remove(VARIABLES_PREFIX, Keys.FORK_HEADS.getBytes());
+      this.remove(Bytes.EMPTY, Keys.SEQ_NO_STORE.getBytes());
+    }
+  }
+}

--- a/src/main/java/org/hyperledger/bela/components/bonsai/BonsaiTrieLogNode.java
+++ b/src/main/java/org/hyperledger/bela/components/bonsai/BonsaiTrieLogNode.java
@@ -1,11 +1,5 @@
 package org.hyperledger.bela.components.bonsai;
 
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Stream;
-
 import com.googlecode.lanterna.gui2.Borders;
 import com.googlecode.lanterna.gui2.Component;
 import com.googlecode.lanterna.gui2.Panel;
@@ -15,9 +9,12 @@ import org.hyperledger.besu.datatypes.AccountValue;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.StorageSlotKey;
-import org.hyperledger.besu.ethereum.bonsai.BonsaiValue;
-import org.hyperledger.besu.ethereum.bonsai.trielog.TrieLogLayer;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.DiffBasedValue;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.trielog.TrieLogLayer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public class BonsaiTrieLogNode extends AbstractBonsaiNode {
 
@@ -61,7 +58,7 @@ public class BonsaiTrieLogNode extends AbstractBonsaiNode {
     final List<AddressStorageNode> storageChanges =
         layer.getStorageChanges().entrySet().stream().map(storageChange -> {
           final Address address = storageChange.getKey();
-          final Map<StorageSlotKey, BonsaiValue<UInt256>> tree = storageChange.getValue();
+          final Map<StorageSlotKey, DiffBasedValue<UInt256>> tree = storageChange.getValue();
           return new AddressStorageNode(address, tree);
         }).toList();
     if (!storageChanges.isEmpty()) {

--- a/src/main/java/org/hyperledger/bela/components/bonsai/BonsaiTrieLogView.java
+++ b/src/main/java/org/hyperledger/bela/components/bonsai/BonsaiTrieLogView.java
@@ -5,10 +5,10 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.bela.components.bonsai.queries.TrieQueryValidator;
 import org.hyperledger.bela.utils.StorageProviderFactory;
 import org.hyperledger.besu.datatypes.Hash;
-import org.hyperledger.besu.ethereum.bonsai.trielog.TrieLogFactoryImpl;
-import org.hyperledger.besu.ethereum.bonsai.trielog.TrieLogLayer;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.trielog.TrieLogFactoryImpl;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.trielog.TrieLogLayer;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.trielogs.TrieLogFactory;
 

--- a/src/main/java/org/hyperledger/bela/components/bonsai/queries/TrieQueryValidator.java
+++ b/src/main/java/org/hyperledger/bela/components/bonsai/queries/TrieQueryValidator.java
@@ -1,6 +1,7 @@
 package org.hyperledger.bela.components.bonsai.queries;
 
-import org.hyperledger.besu.ethereum.bonsai.trielog.TrieLogLayer;
+
+import org.hyperledger.besu.ethereum.trie.diffbased.common.trielog.TrieLogLayer;
 
 public interface TrieQueryValidator {
     boolean validate(TrieLogLayer layer);

--- a/src/main/java/org/hyperledger/bela/components/bonsai/queries/ValidateStorageChange.java
+++ b/src/main/java/org/hyperledger/bela/components/bonsai/queries/ValidateStorageChange.java
@@ -3,9 +3,8 @@ package org.hyperledger.bela.components.bonsai.queries;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import org.hyperledger.besu.datatypes.AccountValue;
 import org.hyperledger.besu.datatypes.Hash;
-import org.hyperledger.besu.ethereum.bonsai.BonsaiValue;
-import org.hyperledger.besu.ethereum.bonsai.trielog.TrieLogLayer;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.DiffBasedValue;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.trielog.TrieLogLayer;
 
 import static kr.pe.kwonnam.slf4jlambda.LambdaLoggerFactory.getLogger;
 
@@ -21,7 +20,7 @@ public class ValidateStorageChange implements TrieQueryValidator {
     @Override
     public boolean validate(final TrieLogLayer layer) {
         return layer.getAccountChanges().entrySet().stream().anyMatch(accountChange -> {
-            final BonsaiValue<AccountValue> value = accountChange.getValue();
+            final DiffBasedValue<AccountValue> value = accountChange.getValue();
             final AccountValue prior = value.getPrior();
             final AccountValue updated = value.getUpdated();
             if ((prior != null && targetHash.equals(prior.getStorageRoot())) || (updated != null && targetHash.equals(updated.getStorageRoot()))) {

--- a/src/main/java/org/hyperledger/bela/config/BelaConfigurationImpl.java
+++ b/src/main/java/org/hyperledger/bela/config/BelaConfigurationImpl.java
@@ -1,7 +1,12 @@
 package org.hyperledger.bela.config;
 
 import java.nio.file.Path;
+import java.util.Optional;
+
+import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.plugin.services.BesuConfiguration;
+import org.hyperledger.besu.plugin.services.storage.DataStorageConfiguration;
+import org.hyperledger.besu.plugin.services.storage.DataStorageFormat;
 
 public class BelaConfigurationImpl implements BesuConfiguration {
 
@@ -14,6 +19,16 @@ public class BelaConfigurationImpl implements BesuConfiguration {
     }
 
     @Override
+    public Optional<String> getRpcHttpHost() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Integer> getRpcHttpPort() {
+        return Optional.empty();
+    }
+
+    @Override
     public Path getStoragePath() {
         return storagePath;
     }
@@ -21,5 +36,20 @@ public class BelaConfigurationImpl implements BesuConfiguration {
     @Override
     public Path getDataPath() {
         return dataPath;
+    }
+
+    @Override
+    public DataStorageFormat getDatabaseFormat() {
+        return null;
+    }
+
+    @Override
+    public Wei getMinGasPrice() {
+        return null;
+    }
+
+    @Override
+    public DataStorageConfiguration getDataStorageConfiguration() {
+        return null;
     }
 }

--- a/src/main/java/org/hyperledger/bela/context/MainNetContext.java
+++ b/src/main/java/org/hyperledger/bela/context/MainNetContext.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.bela.components.bonsai.BelaKeyValueBlockchainStorage;
 import org.hyperledger.bela.utils.StorageProviderFactory;
 import org.hyperledger.besu.BesuInfo;
 import org.hyperledger.besu.config.GenesisConfigFile;
@@ -350,7 +351,8 @@ public class MainNetContext implements BelaContext {
     private static BlockchainStorage getBlockChainStorage(StorageProvider provider) {
         final KeyValueStorage keyValueStorage = provider.getStorageBySegmentIdentifier(BLOCKCHAIN);
         final VariablesStorage variableStorage = new VariablesKeyValueStorage(provider.getStorageBySegmentIdentifier(VARIABLES));
-        return new KeyValueStoragePrefixedKeyBlockchainStorage(keyValueStorage, variableStorage, new MainnetBlockHeaderFunctions(), true);
+        // temporary until changes to besu main enable the creation of db without auto-migrating data
+        return new BelaKeyValueBlockchainStorage(keyValueStorage, variableStorage, new MainnetBlockHeaderFunctions(), true);
     }
 
     private StorageProvider getProvider() {

--- a/src/main/java/org/hyperledger/bela/context/MainNetContext.java
+++ b/src/main/java/org/hyperledger/bela/context/MainNetContext.java
@@ -1,33 +1,20 @@
 package org.hyperledger.bela.context;
 
-import java.io.IOException;
-import java.math.BigInteger;
-import java.time.Clock;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Supplier;
-
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import io.vertx.core.Vertx;
-import jnr.ffi.Variable;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.bela.utils.StorageProviderFactory;
 import org.hyperledger.besu.BesuInfo;
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.config.JsonGenesisConfigOptions;
-import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.ProtocolContext;
-import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateProvider;
-import org.hyperledger.besu.ethereum.bonsai.cache.CachedMerkleTrieLoader;
-import org.hyperledger.besu.ethereum.bonsai.storage.BonsaiWorldStateKeyValueStorage;
+import org.hyperledger.besu.ethereum.chain.BadBlockManager;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.BlockchainStorage;
 import org.hyperledger.besu.ethereum.chain.DefaultBlockchain;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
@@ -41,15 +28,17 @@ import org.hyperledger.besu.ethereum.eth.manager.EthMessages;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
-import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
-import org.hyperledger.besu.ethereum.forkid.ForkIdManager;
 import org.hyperledger.besu.ethereum.eth.manager.MergePeerFilter;
 import org.hyperledger.besu.ethereum.eth.peervalidation.PeerValidator;
+import org.hyperledger.besu.ethereum.eth.sync.SyncMode;
+import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
+import org.hyperledger.besu.ethereum.eth.transactions.BlobCache;
 import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolFactory;
+import org.hyperledger.besu.ethereum.forkid.ForkIdManager;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
@@ -61,24 +50,31 @@ import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.network.ProtocolManager;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.SubProtocol;
-import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStoragePrefixedKeyBlockchainStorage;
 import org.hyperledger.besu.ethereum.storage.keyvalue.VariablesKeyValueStorage;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.BonsaiWorldStateProvider;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoader;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
-import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
+import org.hyperledger.besu.services.BesuPluginContextImpl;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
+import java.math.BigInteger;
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
 import static org.hyperledger.besu.config.JsonUtil.normalizeKeys;
-import static org.hyperledger.besu.ethereum.core.MiningParameters.DEFAULT_MAX_OMMERS_DEPTH;
-import static org.hyperledger.besu.ethereum.core.MiningParameters.DEFAULT_POW_JOB_TTL;
-import static org.hyperledger.besu.ethereum.core.MiningParameters.DEFAULT_REMOTE_SEALERS_LIMIT;
-import static org.hyperledger.besu.ethereum.core.MiningParameters.DEFAULT_REMOTE_SEALERS_TTL;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.BLOCKCHAIN;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.VARIABLES;
 
@@ -115,7 +111,8 @@ public class MainNetContext implements BelaContext {
     @Override
     public ProtocolSchedule getProtocolSchedule() {
         return MainnetProtocolSchedule.fromConfig(
-                getMainNetConfigOptions(), PrivacyParameters.DEFAULT, false, EvmConfiguration.DEFAULT);
+                getMainNetConfigOptions(), PrivacyParameters.DEFAULT, false, EvmConfiguration.DEFAULT,
+            MiningParameters.newDefault(), new BadBlockManager(), false, metricsSystem);
     }
 
     @Override
@@ -135,7 +132,9 @@ public class MainNetContext implements BelaContext {
                         clock,
                         getMetricsSystem(),
                         1000,
-                        Collections.emptyList(), localNodeKey, maxPeers, maxPeers, maxPeers, false);
+                        Collections.emptyList(),
+                        localNodeKey,
+                        maxPeers, maxPeers, false, SyncMode.FULL, getForkIdManager());
         final EthScheduler scheduler = getEthScheduler();
         ethContext = new EthContext(ethPeers, new EthMessages(), new EthMessages(), scheduler);
         return ethContext;
@@ -301,63 +300,57 @@ public class MainNetContext implements BelaContext {
                 getClock(),
                 getMetricsSystem(),
                 getSyncState(),
-                getMiningParameters(),
-                getTransactionPoolConfiguration()
-        );
+                TransactionPoolConfiguration.DEFAULT,
+                new BlobCache(),
+                MiningParameters.MINING_DISABLED);
     }
 
     private TransactionPoolConfiguration getTransactionPoolConfiguration() {
         return ImmutableTransactionPoolConfiguration.DEFAULT;
     }
 
-    private MiningParameters getMiningParameters() {
-        final Wei minTransactionGasPrice = Wei.ZERO;
-        // Extradata and coinbase can be configured on a per-block level via the json file
-        final Address coinbase = Address.ZERO;
-        final Bytes extraData = Bytes.EMPTY;
-        return new MiningParameters.Builder()
-                .coinbase(coinbase)
-                .minTransactionGasPrice(minTransactionGasPrice)
-                .extraData(extraData)
-                .miningEnabled(false)
-                .stratumMiningEnabled(false)
-                .stratumNetworkInterface("0.0.0.0")
-                .stratumPort(8008)
-                .stratumExtranonce("080c")
-                .maybeNonceGenerator(new IncrementingNonceGenerator(0))
-                .minBlockOccupancyRatio(0.0)
-                .remoteSealersLimit(DEFAULT_REMOTE_SEALERS_LIMIT)
-                .remoteSealersTimeToLive(DEFAULT_REMOTE_SEALERS_TTL)
-                .powJobTimeToLive(DEFAULT_POW_JOB_TTL)
-                .maxOmmerDepth(DEFAULT_MAX_OMMERS_DEPTH)
-                .build();
-    }
 
     private ProtocolContext getProtocolContext() {
         return ProtocolContext.init(getBlockChain(), getWorldStateArchive(), getProtocolSchedule(),
-                (blockchain, worldStateArchive, protocolSchedule) -> null, Optional.empty());
+                (blockchain, worldStateArchive, protocolSchedule) -> null, new BadBlockManager());
     }
 
-    private BonsaiWorldStateProvider getWorldStateArchive() {
+    //TODO: Visible for re-use elsewhere.
+    public BonsaiWorldStateProvider getWorldStateArchive() {
+        return getWorldStateArchive(getProvider(), getBlockChain());
+    }
+
+    // TODO: This should probably move to a common/util class
+    public static BonsaiWorldStateProvider getWorldStateArchive(StorageProvider provider, Blockchain blockchain) {
         final NoOpMetricsSystem noOpMetricsSystem = new NoOpMetricsSystem();
         return new BonsaiWorldStateProvider(
-            getProvider(), getBlockChain(),
-            new CachedMerkleTrieLoader(noOpMetricsSystem),noOpMetricsSystem, null);
+            (BonsaiWorldStateKeyValueStorage)
+                provider.createWorldStateStorage(DataStorageConfiguration.DEFAULT_BONSAI_CONFIG),
+            blockchain,
+            Optional.empty(),
+            new BonsaiCachedMerkleTrieLoader(noOpMetricsSystem),
+            new BesuPluginContextImpl(),
+            EvmConfiguration.DEFAULT
+        );
     }
 
     private BonsaiWorldStateKeyValueStorage getWorldStateStorage() {
-        return new BonsaiWorldStateKeyValueStorage(getProvider(), new NoOpMetricsSystem());
+        return new BonsaiWorldStateKeyValueStorage(getProvider(), new NoOpMetricsSystem(), DataStorageConfiguration.DEFAULT_BONSAI_CONFIG);
     }
 
     private MutableBlockchain getBlockChain() {
         return   (MutableBlockchain) DefaultBlockchain
-                .create(getBlockChainStorage(), new NoOpMetricsSystem(), 0L);
+            .create(getBlockChainStorage(), new NoOpMetricsSystem(), 0L);
     }
 
     private BlockchainStorage getBlockChainStorage() {
-        final KeyValueStorage keyValueStorage = getProvider().getStorageBySegmentIdentifier(BLOCKCHAIN);
-        final VariablesStorage variableStorage = new VariablesKeyValueStorage(getProvider().getStorageBySegmentIdentifier(VARIABLES));
-        return new KeyValueStoragePrefixedKeyBlockchainStorage(keyValueStorage, variableStorage, new MainnetBlockHeaderFunctions());
+        return getBlockChainStorage(getProvider());
+    }
+
+    private static BlockchainStorage getBlockChainStorage(StorageProvider provider) {
+        final KeyValueStorage keyValueStorage = provider.getStorageBySegmentIdentifier(BLOCKCHAIN);
+        final VariablesStorage variableStorage = new VariablesKeyValueStorage(provider.getStorageBySegmentIdentifier(VARIABLES));
+        return new KeyValueStoragePrefixedKeyBlockchainStorage(keyValueStorage, variableStorage, new MainnetBlockHeaderFunctions(), true);
     }
 
     private StorageProvider getProvider() {

--- a/src/main/java/org/hyperledger/bela/converter/RocksDBKeyValueStorageConverterFactory.java
+++ b/src/main/java/org/hyperledger/bela/converter/RocksDBKeyValueStorageConverterFactory.java
@@ -35,7 +35,7 @@ public class RocksDBKeyValueStorageConverterFactory implements KeyValueStorageFa
     private static SegmentedKeyValueStorage segmentedStorage;
     private final List<SegmentIdentifier> segments;
     private final RocksDBMetricsFactory rocksDBMetricsFactory;
-    private static final Set<Integer> SUPPORTED_VERSIONS = Set.of(1, 2);
+    private static final Set<Integer> SUPPORTED_VERSIONS = Set.of(1, 2, 3);
 
 
     private final Supplier<RocksDBFactoryConfiguration> configuration;
@@ -122,7 +122,7 @@ public class RocksDBKeyValueStorageConverterFactory implements KeyValueStorageFa
         final int databaseVersion;
 
         if (databaseExists) {
-            databaseVersion = DatabaseMetadata.lookUpFrom(dataDir).getVersion();
+            databaseVersion = DatabaseMetadata.lookUpFrom(dataDir).getVersionedStorageFormat().getVersion();
             LOG.info("Existing database detected at {}. Version {}", dataDir, databaseVersion);
         } else {
             final String message = "No existing database detected at " + dataDir;

--- a/src/main/java/org/hyperledger/bela/utils/BlockChainBrowser.java
+++ b/src/main/java/org/hyperledger/bela/utils/BlockChainBrowser.java
@@ -25,9 +25,9 @@ import org.hyperledger.bela.components.BlockPanel;
 import org.hyperledger.bela.components.SummaryPanel;
 import org.hyperledger.bela.model.BlockResult;
 import org.hyperledger.besu.datatypes.Hash;
-import org.hyperledger.besu.ethereum.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.chain.DefaultBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 
 public class BlockChainBrowser {
 

--- a/src/main/java/org/hyperledger/bela/utils/BlockChainContext.java
+++ b/src/main/java/org/hyperledger/bela/utils/BlockChainContext.java
@@ -1,16 +1,17 @@
 package org.hyperledger.bela.utils;
 
-import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateProvider;
-import org.hyperledger.besu.ethereum.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.BonsaiWorldStateProvider;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 
 public class BlockChainContext {
 
-    private final Blockchain blockchain;
+    private final MutableBlockchain blockchain;
     private final BonsaiWorldStateKeyValueStorage worldStateStorage;
     private final BonsaiWorldStateProvider bonsaiWorldStateArchive;
 
-    public BlockChainContext(final Blockchain blockchain,
+    public BlockChainContext(final MutableBlockchain blockchain,
                              final BonsaiWorldStateKeyValueStorage worldStateStorage,
                              final BonsaiWorldStateProvider bonsaiWorldStateArchive) {
         this.blockchain = blockchain;
@@ -18,7 +19,7 @@ public class BlockChainContext {
         this.bonsaiWorldStateArchive = bonsaiWorldStateArchive;
     }
 
-    public Blockchain getBlockchain() {
+    public MutableBlockchain getBlockchain() {
         return blockchain;
     }
 

--- a/src/main/java/org/hyperledger/bela/utils/ConsensusDetector.java
+++ b/src/main/java/org/hyperledger/bela/utils/ConsensusDetector.java
@@ -16,7 +16,8 @@ public class ConsensusDetector {
     public static CONSENSUS_TYPE detectConsensusMechanism(
         final KeyValueStorage keyValueStorage,
         final VariablesStorage variablesStorage) {
-        var storage = new KeyValueStoragePrefixedKeyBlockchainStorage(keyValueStorage, variablesStorage, new MainnetBlockHeaderFunctions());
+        // TODO: should detect this from file, centralize this logic in a common util
+        var storage = new KeyValueStoragePrefixedKeyBlockchainStorage(keyValueStorage, variablesStorage, new MainnetBlockHeaderFunctions(), false);
         var genesisHash = storage.getBlockHash(BlockHeader.GENESIS_BLOCK_NUMBER).orElseThrow();
         var genesisBlockHeader = storage.getBlockHeader(genesisHash).orElseThrow();
         var extraData = genesisBlockHeader.getExtraData();

--- a/src/main/java/org/hyperledger/bela/utils/TraceUtils.java
+++ b/src/main/java/org/hyperledger/bela/utils/TraceUtils.java
@@ -12,6 +12,7 @@ import org.hyperledger.besu.cli.config.EthNetworkConfig;
 import org.hyperledger.besu.cli.config.NetworkName;
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.GenesisConfigOptions;
+import org.hyperledger.besu.consensus.clique.CliqueForksSchedulesFactory;
 import org.hyperledger.besu.consensus.clique.CliqueProtocolSchedule;
 import org.hyperledger.besu.consensus.ibft.IbftExtraDataCodec;
 import org.hyperledger.besu.consensus.ibft.IbftForksSchedulesFactory;
@@ -23,30 +24,42 @@ import org.hyperledger.besu.crypto.KeyPairUtil;
 import org.hyperledger.besu.cryptoservices.KeyPairSecurityModule;
 import org.hyperledger.besu.cryptoservices.NodeKey;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.TraceTransaction;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockReplay;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.FlatTrace;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.chain.BadBlockManager;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.BonsaiWorldStateProvider;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 
 import static org.hyperledger.bela.windows.Constants.NODE_KEY;
 import static org.hyperledger.bela.windows.Constants.NODE_PATH_DEFAULT;
 
 public class TraceUtils {
-
+    private static final BadBlockManager badBlockManager = new BadBlockManager();
     public static Stream<FlatTrace> traceTransaction(final Preferences preferences,
                                                      final BlockChainContext context, final Hash transactionHash) {
+
         final String genesisConfig = getGenesisConfig(preferences);
         final ProtocolSchedule protocolSchedule = getProtocolSchedule(preferences, genesisConfig);
-        var blockchain = context.getBlockchain();
-        var bonsaiWorldStateArchive = context.getBonsaiWorldStateProvider();
-        final BlockReplay blockReplay = new BlockReplay(protocolSchedule, blockchain);
-        final BlockchainQueries blockchainQueries = new BlockchainQueries(blockchain,
-                bonsaiWorldStateArchive);
+        final MutableBlockchain blockchain = context.getBlockchain();
+        final BonsaiWorldStateProvider bonsaiWorldStateArchive = context.getBonsaiWorldStateProvider();
+        // caveat - null consensus context here, with an expectation it won't be used;
+        final ProtocolContext protocolContext = new ProtocolContext(
+            blockchain, bonsaiWorldStateArchive, null, badBlockManager);
+
+        final BlockReplay blockReplay = new BlockReplay(protocolSchedule, protocolContext, blockchain);
+        final BlockchainQueries blockchainQueries = new BlockchainQueries(protocolSchedule, blockchain,
+                bonsaiWorldStateArchive, MiningParameters.MINING_DISABLED);
         final TraceTransaction traceTransaction = new TraceTransaction(
                 () -> new BlockTracer(blockReplay), protocolSchedule, blockchainQueries);
         return traceTransaction.resultByTransactionHash(transactionHash);
@@ -54,11 +67,12 @@ public class TraceUtils {
 
     private static String getGenesisConfig(final Preferences preferences) {
         final String networkOrGenesisPath = preferences.get(Constants.GENESIS_PATH, "");
-        final Optional<NetworkName> maybeNetworkName = Arrays.stream(NetworkName.values())
-                .filter(n -> n.name().equalsIgnoreCase(networkOrGenesisPath))
-                .findFirst();
-        return maybeNetworkName.map(EthNetworkConfig::getNetworkConfig)
-                .map(EthNetworkConfig::getGenesisConfig)
+        final Optional<String> maybeGenesisConfig = Arrays.stream(NetworkName.values())
+            .filter(n -> n.name().equalsIgnoreCase(networkOrGenesisPath))
+            .map(NetworkName::getGenesisFile)
+            .findFirst();
+
+        return maybeGenesisConfig
                 .orElseGet(() -> {
                             try {
                                 return Files.readString(Path.of(networkOrGenesisPath));
@@ -75,24 +89,30 @@ public class TraceUtils {
                 genesisConfigString);
         final GenesisConfigOptions configOptions = config.getConfigOptions();
         if (configOptions.isEthHash()) {
-            return MainnetProtocolSchedule.fromConfig(configOptions, true,
-                    EvmConfiguration.DEFAULT);
+            return MainnetProtocolSchedule.fromConfig(
+                configOptions, true, EvmConfiguration.DEFAULT,MiningParameters.MINING_DISABLED,
+                badBlockManager, false, new NoOpMetricsSystem());
         } else if (configOptions.isClique()) {
             final Path nodeKeyPath = Path.of(preferences.get(NODE_KEY, NODE_PATH_DEFAULT));
             final NodeKey nodeKey = new NodeKey(
                     new KeyPairSecurityModule(KeyPairUtil.loadKeyPair(nodeKeyPath)));
-            return CliqueProtocolSchedule.create(configOptions, nodeKey, true,
-                    EvmConfiguration.DEFAULT);
+            var forkSchedule = CliqueForksSchedulesFactory.create(configOptions);
+            return CliqueProtocolSchedule.create(
+                configOptions, forkSchedule, nodeKey, true,
+                EvmConfiguration.DEFAULT, MiningParameters.MINING_DISABLED,
+                badBlockManager, false, new NoOpMetricsSystem());
         } else if (configOptions.isIbft2()) {
             var forkSchedule = IbftForksSchedulesFactory.create(configOptions);
-            return IbftProtocolScheduleBuilder.create(configOptions, forkSchedule, PrivacyParameters.DEFAULT,
-                    true, new IbftExtraDataCodec(),
-                    EvmConfiguration.DEFAULT);
+            return IbftProtocolScheduleBuilder.create(configOptions, forkSchedule,
+                new IbftExtraDataCodec(), EvmConfiguration.DEFAULT,
+                MiningParameters.MINING_DISABLED, badBlockManager, false,
+                new NoOpMetricsSystem());
         } else if (configOptions.isQbft()) {
             var forkSchedule = QbftForksSchedulesFactory.create(configOptions);
-            return QbftProtocolScheduleBuilder.create(configOptions, forkSchedule, PrivacyParameters.DEFAULT,
-                    true, new QbftExtraDataCodec(),
-                    EvmConfiguration.DEFAULT);
+            return QbftProtocolScheduleBuilder.create(
+                configOptions, forkSchedule, true, new QbftExtraDataCodec(),
+                MiningParameters.MINING_DISABLED, badBlockManager, false,
+                new NoOpMetricsSystem());
         } else {
             throw new UnsupportedOperationException("Unknown protocol schedule");
         }

--- a/src/main/java/org/hyperledger/bela/windows/BonsaiTrieLogLayersViewer.java
+++ b/src/main/java/org/hyperledger/bela/windows/BonsaiTrieLogLayersViewer.java
@@ -17,18 +17,19 @@ import org.hyperledger.bela.components.bonsai.BonsaiTrieLogView;
 import org.hyperledger.bela.components.bonsai.RootTrieLogSearchResult;
 import org.hyperledger.bela.components.bonsai.queries.BonsaiTrieQuery;
 import org.hyperledger.bela.components.bonsai.queries.TrieQueryValidator;
+import org.hyperledger.bela.context.MainNetContext;
 import org.hyperledger.bela.dialogs.BelaDialog;
 import org.hyperledger.bela.dialogs.ProgressBarPopup;
 import org.hyperledger.bela.utils.BlockChainContext;
 import org.hyperledger.bela.utils.BlockChainContextFactory;
 import org.hyperledger.bela.utils.StorageProviderFactory;
 import org.hyperledger.besu.datatypes.Hash;
-import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateProvider;
-import org.hyperledger.besu.ethereum.bonsai.cache.CachedMerkleTrieLoader;
-import org.hyperledger.besu.ethereum.bonsai.worldview.BonsaiWorldStateUpdateAccumulator;
 import org.hyperledger.besu.ethereum.chain.ChainHead;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.BonsaiWorldStateProvider;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoader;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.worldview.BonsaiWorldStateUpdateAccumulator;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 
@@ -46,13 +47,15 @@ public class BonsaiTrieLogLayersViewer extends AbstractBelaWindow {
 
     private final WindowBasedTextGUI gui;
     private final StorageProviderFactory storageProviderFactory;
-
     private final BonsaiTrieLogView view;
+    private final BonsaiWorldStateProvider archive;
+
 
     public BonsaiTrieLogLayersViewer(final WindowBasedTextGUI gui, final StorageProviderFactory storageProviderFactory) {
 
         this.gui = gui;
         this.storageProviderFactory = storageProviderFactory;
+        this.archive = new MainNetContext(storageProviderFactory).getWorldStateArchive();
 
         this.view = new BonsaiTrieLogView(storageProviderFactory);
     }
@@ -150,17 +153,7 @@ public class BonsaiTrieLogLayersViewer extends AbstractBelaWindow {
     }
 
     private BonsaiWorldStateUpdateAccumulator getBonsaiWorldStateAccumulator() {
-        final StorageProvider provider = storageProviderFactory.createProvider();
-        final BlockChainContext blockChainContext = BlockChainContextFactory.createBlockChainContext(provider);
-
-        final NoOpMetricsSystem noOpMetricsSystem = new NoOpMetricsSystem();
-        final BonsaiWorldStateProvider archive = new BonsaiWorldStateProvider(
-            provider,
-            blockChainContext.getBlockchain(),
-            new CachedMerkleTrieLoader(noOpMetricsSystem),noOpMetricsSystem, null);
-
         return (BonsaiWorldStateUpdateAccumulator) archive.getMutable().updater();
-
     }
 
 

--- a/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/BelaRocksDBColumnarKeyValueStorage.java
+++ b/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/BelaRocksDBColumnarKeyValueStorage.java
@@ -34,8 +34,8 @@ import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 /** Optimistic RocksDB Columnar key value storage for Bela */
 public class BelaRocksDBColumnarKeyValueStorage extends RocksDBColumnarKeyValueStorage
@@ -104,7 +104,7 @@ public class BelaRocksDBColumnarKeyValueStorage extends RocksDBColumnarKeyValueS
 
   @Override
   public SnappedKeyValueStorage takeSnapshot() {
-    return new LayeredKeyValueStorage(new HashMap<>(), this);
+    return new LayeredKeyValueStorage(new ConcurrentHashMap<>(), this);
   }
 
   public void remove(SegmentIdentifier segment) {


### PR DESCRIPTION
Initial PR to get bela working with 24.8.0

There are a couple TODOs that we should try to DRY up and make util classes from, notably:
* constructing blockchain 
* constructing bonsai archive
* reading the database metadata to determine if receipt compaction
* Most importantly, we need to update Besu to offer a non-storage-modifying constructor (or allow overriding) for [KeyValueStoragePrefixedKeyBlockchainStorage](https://github.com/hyperledger/besu/blob/main/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueStoragePrefixedKeyBlockchainStorage.java#L73)