### PR TITLE
Fixes for FOREST mode

### DIFF
--- a/src/main/java/org/hyperledger/bela/Bela.java
+++ b/src/main/java/org/hyperledger/bela/Bela.java
@@ -1,6 +1,7 @@
 package org.hyperledger.bela;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.prefs.Preferences;
 import com.googlecode.lanterna.TerminalSize;
 import com.googlecode.lanterna.bundle.LanternaThemes;
@@ -10,6 +11,7 @@ import com.googlecode.lanterna.gui2.WindowBasedTextGUI;
 import com.googlecode.lanterna.screen.Screen;
 import com.googlecode.lanterna.terminal.DefaultTerminalFactory;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
+import org.hyperledger.bela.config.BesuDataStorageConfigurationUtil;
 import org.hyperledger.bela.utils.StorageProviderFactory;
 import org.hyperledger.bela.windows.BlockChainBrowserWindow;
 import org.hyperledger.bela.windows.BonsaiStorageBrowserWindow;
@@ -24,11 +26,12 @@ import org.hyperledger.bela.windows.RocksDBViewer;
 import org.hyperledger.bela.windows.SegmentManipulationWindow;
 import org.hyperledger.bela.windows.SettingsWindow;
 import org.hyperledger.besu.BesuInfo;
+import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
+import org.hyperledger.besu.plugin.services.storage.DataStorageFormat;
 
 import static kr.pe.kwonnam.slf4jlambda.LambdaLoggerFactory.getLogger;
-import static org.hyperledger.bela.windows.Constants.DATA_PATH;
-import static org.hyperledger.bela.windows.Constants.DEFAULT_THEME;
-import static org.hyperledger.bela.windows.Constants.THEME_KEY;
+import static org.hyperledger.bela.config.BesuDataStorageConfigurationUtil.getDataStorageConfiguration;
+import static org.hyperledger.bela.windows.Constants.*;
 
 public class Bela {
     private static final LambdaLogger log = getLogger(Bela.class);
@@ -47,20 +50,24 @@ public class Bela {
             final WindowBasedTextGUI gui = new MultiWindowTextGUI(screen);
 
             StorageProviderFactory storageProviderFactory = new StorageProviderFactory(gui,preferences);
+            DataStorageConfiguration dataStorageConfig = getDataStorageConfiguration(Path.of(preferences.get(DATA_PATH, DATA_PATH_DEFAULT)));
+            DataStorageFormat dataStorageFormat = dataStorageConfig.getDataStorageFormat();
 
             gui.setTheme(LanternaThemes.getRegisteredTheme(preferences.get(THEME_KEY, DEFAULT_THEME)));
             MainWindow mainWindow = new MainWindow(gui, preferences);
             final SettingsWindow config = new SettingsWindow(gui, preferences);
             mainWindow.registerWindow(config);
             mainWindow.registerWindow(new BlockChainBrowserWindow(storageProviderFactory, gui, preferences));
-            mainWindow.registerWindow(new BonsaiTreeVerifierWindow(gui, storageProviderFactory));
             mainWindow.registerWindow(new DatabaseConversionWindow(storageProviderFactory));
             mainWindow.registerWindow(new LogoWindow());
             mainWindow.registerWindow(new P2PManagementWindow(gui, storageProviderFactory, preferences));
             mainWindow.registerWindow(new RocksDBViewer(gui, storageProviderFactory));
             mainWindow.registerWindow(new SegmentManipulationWindow(gui, storageProviderFactory, preferences));
-            mainWindow.registerWindow(new BonsaiStorageBrowserWindow(gui, storageProviderFactory));
-            mainWindow.registerWindow(new BonsaiTrieLogLayersViewer(gui, storageProviderFactory));
+            if (DataStorageFormat.BONSAI.equals(dataStorageFormat)) {
+              mainWindow.registerWindow(new BonsaiStorageBrowserWindow(gui, storageProviderFactory));
+              mainWindow.registerWindow(new BonsaiTrieLogLayersViewer(gui, storageProviderFactory));
+              mainWindow.registerWindow(new BonsaiTreeVerifierWindow(gui, storageProviderFactory));
+            }
             final Window window = mainWindow.createWindow();
             gui.addWindowAndWait(window);
             mainWindow.close();

--- a/src/main/java/org/hyperledger/bela/Bela.java
+++ b/src/main/java/org/hyperledger/bela/Bela.java
@@ -11,7 +11,7 @@ import com.googlecode.lanterna.gui2.WindowBasedTextGUI;
 import com.googlecode.lanterna.screen.Screen;
 import com.googlecode.lanterna.terminal.DefaultTerminalFactory;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
-import org.hyperledger.bela.config.BesuDataStorageConfigurationUtil;
+import org.hyperledger.bela.context.MainNetContext;
 import org.hyperledger.bela.utils.StorageProviderFactory;
 import org.hyperledger.bela.windows.BlockChainBrowserWindow;
 import org.hyperledger.bela.windows.BonsaiStorageBrowserWindow;
@@ -52,21 +52,23 @@ public class Bela {
             StorageProviderFactory storageProviderFactory = new StorageProviderFactory(gui,preferences);
             DataStorageConfiguration dataStorageConfig = getDataStorageConfiguration(Path.of(preferences.get(DATA_PATH, DATA_PATH_DEFAULT)));
             DataStorageFormat dataStorageFormat = dataStorageConfig.getDataStorageFormat();
+            MainNetContext mainNetContext = new MainNetContext(dataStorageConfig, storageProviderFactory);
 
             gui.setTheme(LanternaThemes.getRegisteredTheme(preferences.get(THEME_KEY, DEFAULT_THEME)));
             MainWindow mainWindow = new MainWindow(gui, preferences);
             final SettingsWindow config = new SettingsWindow(gui, preferences);
             mainWindow.registerWindow(config);
-            mainWindow.registerWindow(new BlockChainBrowserWindow(storageProviderFactory, gui, preferences));
-            mainWindow.registerWindow(new DatabaseConversionWindow(storageProviderFactory));
+            mainWindow.registerWindow(new BlockChainBrowserWindow(mainNetContext, gui, preferences));
+            mainWindow.registerWindow(new DatabaseConversionWindow(mainNetContext));
             mainWindow.registerWindow(new LogoWindow());
-            mainWindow.registerWindow(new P2PManagementWindow(gui, storageProviderFactory, preferences));
-            mainWindow.registerWindow(new RocksDBViewer(gui, storageProviderFactory));
+            mainWindow.registerWindow(new P2PManagementWindow(gui, mainNetContext));
+            mainWindow.registerWindow(new RocksDBViewer(gui, mainNetContext));
+            // TODO SegmentManipulationWindow is the main culprit for the storageProviderFactory dependency
             mainWindow.registerWindow(new SegmentManipulationWindow(gui, storageProviderFactory, preferences));
             if (DataStorageFormat.BONSAI.equals(dataStorageFormat)) {
-              mainWindow.registerWindow(new BonsaiStorageBrowserWindow(gui, storageProviderFactory));
-              mainWindow.registerWindow(new BonsaiTrieLogLayersViewer(gui, storageProviderFactory));
-              mainWindow.registerWindow(new BonsaiTreeVerifierWindow(gui, storageProviderFactory));
+              mainWindow.registerWindow(new BonsaiStorageBrowserWindow(gui, mainNetContext));
+              mainWindow.registerWindow(new BonsaiTrieLogLayersViewer(gui, mainNetContext));
+              mainWindow.registerWindow(new BonsaiTreeVerifierWindow(gui, mainNetContext));
             }
             final Window window = mainWindow.createWindow();
             gui.addWindowAndWait(window);

--- a/src/main/java/org/hyperledger/bela/components/bonsai/BonsaiStorageView.java
+++ b/src/main/java/org/hyperledger/bela/components/bonsai/BonsaiStorageView.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.hyperledger.bela.utils.StorageProviderFactory;
+import org.hyperledger.bela.context.BelaContext;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
@@ -18,21 +18,21 @@ import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import static org.hyperledger.besu.ethereum.trie.CompactEncoding.bytesToPath;
 
 public class BonsaiStorageView extends AbstractBonsaiNodeView {
-    private final StorageProviderFactory storageProviderFactory;
+    private final BelaContext belaContext;
     private KeyValueStorage accountStorage;
     private KeyValueStorage storageStorage;
     private KeyValueStorage trieBranchStorage;
     private KeyValueStorage codeStorage;
 
-    public BonsaiStorageView(final StorageProviderFactory storageProviderFactory) {
-        this.storageProviderFactory = storageProviderFactory;
+    public BonsaiStorageView(final BelaContext belaContext) {
+        this.belaContext = belaContext;
     }
 
     private void initStorage() {
         if (accountStorage != null) {
             return;
         }
-        final StorageProvider provider = storageProviderFactory.createProvider();
+        final StorageProvider provider = belaContext.getProvider();
         accountStorage = provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.ACCOUNT_INFO_STATE);
         codeStorage = provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.CODE_STORAGE);
         storageStorage = provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.ACCOUNT_STORAGE_STORAGE);

--- a/src/main/java/org/hyperledger/bela/components/bonsai/BonsaiTrieLogView.java
+++ b/src/main/java/org/hyperledger/bela/components/bonsai/BonsaiTrieLogView.java
@@ -3,7 +3,7 @@ package org.hyperledger.bela.components.bonsai;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.bela.components.bonsai.queries.TrieQueryValidator;
-import org.hyperledger.bela.utils.StorageProviderFactory;
+import org.hyperledger.bela.context.BelaContext;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
@@ -24,11 +24,11 @@ public class BonsaiTrieLogView extends AbstractBonsaiNodeView {
   private static final TrieLogFactory trieLogFactory = new TrieLogFactoryImpl();
 
 
-  private final StorageProviderFactory storageProviderFactory;
+  private final BelaContext belaContext;
   private BonsaiTrieLogNode bonsaiTrieLogNode;
 
-  public BonsaiTrieLogView(final StorageProviderFactory storageProviderFactory) {
-    this.storageProviderFactory = storageProviderFactory;
+  public BonsaiTrieLogView(final BelaContext belaContext) {
+    this.belaContext = belaContext;
   }
 
   public static Optional<TrieLogLayer> getTrieLog(final KeyValueStorage storage,
@@ -40,7 +40,7 @@ public class BonsaiTrieLogView extends AbstractBonsaiNodeView {
 
   public void updateFromHash(final Hash hash) {
 
-    final StorageProvider provider = storageProviderFactory.createProvider();
+    final StorageProvider provider = belaContext.getProvider();
     final KeyValueStorage storage =
         provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.TRIE_LOG_STORAGE);
     final Optional<TrieLogLayer> trieLog = getTrieLog(storage, hash);
@@ -61,7 +61,7 @@ public class BonsaiTrieLogView extends AbstractBonsaiNodeView {
 
   public void showAllTries() {
 
-    final StorageProvider provider = storageProviderFactory.createProvider();
+    final StorageProvider provider = belaContext.getProvider();
     final KeyValueStorage storage =
         provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.TRIE_LOG_STORAGE);
     final List<BonsaiNode> blocks = storage
@@ -74,7 +74,7 @@ public class BonsaiTrieLogView extends AbstractBonsaiNodeView {
   }
 
   public void executeQuery(final TrieQueryValidator validator) {
-    final StorageProvider provider = storageProviderFactory.createProvider();
+    final StorageProvider provider = belaContext.getProvider();
     final KeyValueStorage storage =
         provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.TRIE_LOG_STORAGE);
     final List<BonsaiNode> results = storage

--- a/src/main/java/org/hyperledger/bela/config/BonsaiUtil.java
+++ b/src/main/java/org/hyperledger/bela/config/BonsaiUtil.java
@@ -1,0 +1,29 @@
+package org.hyperledger.bela.config;
+
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.storage.StorageProvider;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.BonsaiWorldStateProvider;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoader;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
+import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
+import org.hyperledger.besu.evm.internal.EvmConfiguration;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.services.BesuPluginContextImpl;
+
+import java.util.Optional;
+
+public class BonsaiUtil {
+
+    public static BonsaiWorldStateProvider getBonsaiWorldStateArchive(StorageProvider provider, Blockchain blockchain) {
+        final NoOpMetricsSystem noOpMetricsSystem = new NoOpMetricsSystem();
+        return new BonsaiWorldStateProvider(
+                (BonsaiWorldStateKeyValueStorage)
+                        provider.createWorldStateStorage(DataStorageConfiguration.DEFAULT_BONSAI_CONFIG),
+                blockchain,
+                Optional.empty(),
+                new BonsaiCachedMerkleTrieLoader(noOpMetricsSystem),
+                new BesuPluginContextImpl(),
+                EvmConfiguration.DEFAULT
+        );
+    }
+}

--- a/src/main/java/org/hyperledger/bela/context/BelaContext.java
+++ b/src/main/java/org/hyperledger/bela/context/BelaContext.java
@@ -1,13 +1,19 @@
 package org.hyperledger.bela.context;
 
+import java.nio.file.Path;
 import java.util.List;
+
+import org.hyperledger.bela.utils.StorageProviderFactory;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.network.ProtocolManager;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.SubProtocol;
+import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.storage.DataStorageFormat;
 
 public interface BelaContext {
     ProtocolSchedule getProtocolSchedule();
@@ -20,4 +26,15 @@ public interface BelaContext {
     ProtocolManager getProtocolManager();
 
     List<SubProtocol> getSubProtocols();
+
+    StorageProvider getProvider();
+
+    StorageProviderFactory getStorageProviderFactory();
+
+    DataStorageFormat getDataStorageFormat();
+
+    MutableBlockchain getBlockChain();
+
+    Path getDataPath();
+
 }

--- a/src/main/java/org/hyperledger/bela/utils/BlockChainBrowser.java
+++ b/src/main/java/org/hyperledger/bela/utils/BlockChainBrowser.java
@@ -31,7 +31,6 @@ import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldSt
 
 public class BlockChainBrowser {
 
-    private final BonsaiWorldStateKeyValueStorage worldStateStorage;
     private final DefaultBlockchain blockchain;
     private Optional<BlockResult> blockResult;
     private BlockPanel blockPanel;
@@ -39,10 +38,8 @@ public class BlockChainBrowser {
 
 
     public BlockChainBrowser(
-            final DefaultBlockchain blockchain,
-            final BonsaiWorldStateKeyValueStorage worldStateStorage) {
+            final DefaultBlockchain blockchain) {
         this.blockchain = blockchain;
-        this.worldStateStorage = worldStateStorage;
         //fixme
         this.blockResult = getChainHead();
         blockResult.ifPresent(result -> this.blockPanel = new BlockPanel(result));
@@ -54,7 +51,7 @@ public class BlockChainBrowser {
 
 
     public static BlockChainBrowser fromBlockChainContext(final BlockChainContext blockChainContext) {
-        return new BlockChainBrowser((DefaultBlockchain) blockChainContext.getBlockchain(), blockChainContext.getWorldStateStorage());
+        return new BlockChainBrowser((DefaultBlockchain) blockChainContext.getBlockchain());
     }
 
 

--- a/src/main/java/org/hyperledger/bela/utils/BlockChainContext.java
+++ b/src/main/java/org/hyperledger/bela/utils/BlockChainContext.java
@@ -8,23 +8,16 @@ import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldSt
 public class BlockChainContext {
 
     private final MutableBlockchain blockchain;
-    private final BonsaiWorldStateKeyValueStorage worldStateStorage;
     private final BonsaiWorldStateProvider bonsaiWorldStateArchive;
 
     public BlockChainContext(final MutableBlockchain blockchain,
-                             final BonsaiWorldStateKeyValueStorage worldStateStorage,
                              final BonsaiWorldStateProvider bonsaiWorldStateArchive) {
         this.blockchain = blockchain;
-        this.worldStateStorage = worldStateStorage;
         this.bonsaiWorldStateArchive = bonsaiWorldStateArchive;
     }
 
     public MutableBlockchain getBlockchain() {
         return blockchain;
-    }
-
-    public BonsaiWorldStateKeyValueStorage getWorldStateStorage() {
-        return worldStateStorage;
     }
 
     public BonsaiWorldStateProvider getBonsaiWorldStateProvider() {

--- a/src/main/java/org/hyperledger/bela/windows/BlockChainBrowserWindow.java
+++ b/src/main/java/org/hyperledger/bela/windows/BlockChainBrowserWindow.java
@@ -11,11 +11,11 @@ import com.googlecode.lanterna.gui2.dialogs.MessageDialogButton;
 import com.googlecode.lanterna.gui2.dialogs.TextInputDialog;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import org.hyperledger.bela.components.KeyControls;
+import org.hyperledger.bela.context.BelaContext;
 import org.hyperledger.bela.dialogs.BelaDialog;
 import org.hyperledger.bela.utils.BlockChainBrowser;
 import org.hyperledger.bela.utils.BlockChainContext;
 import org.hyperledger.bela.utils.BlockChainContextFactory;
-import org.hyperledger.bela.utils.StorageProviderFactory;
 import org.hyperledger.besu.datatypes.Hash;
 
 import static kr.pe.kwonnam.slf4jlambda.LambdaLoggerFactory.getLogger;
@@ -31,14 +31,14 @@ import static org.hyperledger.bela.windows.Constants.KEY_ROLL_HEAD;
 public class BlockChainBrowserWindow extends AbstractBelaWindow {
     private static final LambdaLogger log = getLogger(BlockChainBrowserWindow.class);
     private final Preferences preferences;
-    private final StorageProviderFactory storageProviderFactory;
+    private final BelaContext belaContext;
     private final WindowBasedTextGUI gui;
     private BlockChainBrowser browser;
     private BlockChainContext context;
 
-    public BlockChainBrowserWindow(final StorageProviderFactory storageProviderFactory,
+    public BlockChainBrowserWindow(final BelaContext belaContext,
                                    final WindowBasedTextGUI gui, final Preferences preferences) {
-        this.storageProviderFactory = storageProviderFactory;
+        this.belaContext = belaContext;
         this.gui = gui;
         this.preferences = preferences;
     }
@@ -70,7 +70,7 @@ public class BlockChainBrowserWindow extends AbstractBelaWindow {
 
     @Override
     public Panel createMainPanel() {
-        context = BlockChainContextFactory.createBlockChainContext(storageProviderFactory.createProvider());
+        context = BlockChainContextFactory.createBlockChainContext(belaContext);
         browser = BlockChainBrowser.fromBlockChainContext(context);
 
         Panel panel = new Panel(new LinearLayout());

--- a/src/main/java/org/hyperledger/bela/windows/BonsaiStorageBrowserWindow.java
+++ b/src/main/java/org/hyperledger/bela/windows/BonsaiStorageBrowserWindow.java
@@ -7,8 +7,8 @@ import com.googlecode.lanterna.gui2.dialogs.TextInputDialog;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import org.hyperledger.bela.components.KeyControls;
 import org.hyperledger.bela.components.bonsai.BonsaiStorageView;
+import org.hyperledger.bela.context.BelaContext;
 import org.hyperledger.bela.dialogs.BelaDialog;
-import org.hyperledger.bela.utils.StorageProviderFactory;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 
@@ -22,14 +22,11 @@ public class BonsaiStorageBrowserWindow extends AbstractBelaWindow {
     private static final LambdaLogger log = getLogger(BonsaiStorageBrowserWindow.class);
 
     private final WindowBasedTextGUI gui;
-    private final StorageProviderFactory storageProviderFactory;
     private final BonsaiStorageView storageView;
 
-    public BonsaiStorageBrowserWindow(final WindowBasedTextGUI gui, final StorageProviderFactory storageProviderFactory) {
-
+    public BonsaiStorageBrowserWindow(final WindowBasedTextGUI gui, final BelaContext belaContext) {
         this.gui = gui;
-        this.storageProviderFactory = storageProviderFactory;
-        this.storageView = new BonsaiStorageView(storageProviderFactory);
+        this.storageView = new BonsaiStorageView(belaContext);
     }
 
 

--- a/src/main/java/org/hyperledger/bela/windows/BonsaiTreeVerifierWindow.java
+++ b/src/main/java/org/hyperledger/bela/windows/BonsaiTreeVerifierWindow.java
@@ -3,7 +3,6 @@ package org.hyperledger.bela.windows;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import com.googlecode.lanterna.TerminalSize;
@@ -17,8 +16,8 @@ import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.bela.components.KeyControls;
+import org.hyperledger.bela.context.BelaContext;
 import org.hyperledger.bela.dialogs.BelaDialog;
-import org.hyperledger.bela.utils.StorageProviderFactory;
 import org.hyperledger.bela.utils.bonsai.BonsaiListener;
 import org.hyperledger.bela.utils.bonsai.BonsaiTraversal;
 import org.hyperledger.bela.utils.bonsai.BonsaiTraversalTrieType;
@@ -34,7 +33,7 @@ public class BonsaiTreeVerifierWindow extends AbstractBelaWindow implements Bons
     public static final String NOT_RUNNING = "Not Running...";
     private static final LambdaLogger log = getLogger(BonsaiTreeVerifierWindow.class);
     private final WindowBasedTextGUI gui;
-    private final StorageProviderFactory storageProviderFactory;
+    private final BelaContext belaContext;
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
     private final Label runningLabel = new Label(NOT_RUNNING);
     private final Label counterLabel = new Label("0");
@@ -43,9 +42,9 @@ public class BonsaiTreeVerifierWindow extends AbstractBelaWindow implements Bons
     AtomicLong visited = new AtomicLong(0);
     private Future<?> execution;
 
-    public BonsaiTreeVerifierWindow(final WindowBasedTextGUI gui, final StorageProviderFactory storageProviderFactory) {
+    public BonsaiTreeVerifierWindow(final WindowBasedTextGUI gui, final BelaContext belaContext) {
         this.gui = gui;
-        this.storageProviderFactory = storageProviderFactory;
+        this.belaContext = belaContext;
         logTextBox.setReadOnly(true);
     }
 
@@ -90,7 +89,7 @@ public class BonsaiTreeVerifierWindow extends AbstractBelaWindow implements Bons
         Thread.yield();
         logTextBox.setText("");
         visited.set(0);
-        final StorageProvider storageProvider = storageProviderFactory.createProvider();
+        final StorageProvider storageProvider = belaContext.getProvider();
         this.bonsaiTraversal.set(new BonsaiTraversal(storageProvider, this));
         execution = executorService.submit(() -> {
             try {
@@ -134,7 +133,7 @@ public class BonsaiTreeVerifierWindow extends AbstractBelaWindow implements Bons
         logTextBox.setText("");
         visited.set(0);
 
-        final StorageProvider provider = storageProviderFactory.createProvider();
+        final StorageProvider provider = belaContext.getProvider();
         this.bonsaiTraversal.set(new BonsaiTraversal(provider, this));
 
         execution = executorService.submit(() -> {

--- a/src/main/java/org/hyperledger/bela/windows/P2PManagementWindow.java
+++ b/src/main/java/org/hyperledger/bela/windows/P2PManagementWindow.java
@@ -10,7 +10,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
 import com.googlecode.lanterna.gui2.Direction;
 import com.googlecode.lanterna.gui2.LinearLayout;
@@ -24,10 +23,8 @@ import org.hyperledger.bela.components.Counter;
 import org.hyperledger.bela.components.KeyControls;
 import org.hyperledger.bela.context.BelaContext;
 import org.hyperledger.bela.context.BelaP2PNetworkFacade;
-import org.hyperledger.bela.context.MainNetContext;
 import org.hyperledger.bela.dialogs.BelaDialog;
 import org.hyperledger.bela.utils.ConnectionMessageMonitor;
-import org.hyperledger.bela.utils.StorageProviderFactory;
 import org.hyperledger.bela.utils.hacks.SentMessageMonitor;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -51,24 +48,20 @@ import static kr.pe.kwonnam.slf4jlambda.LambdaLoggerFactory.getLogger;
 public class P2PManagementWindow extends AbstractBelaWindow implements MessageCallback, ConnectCallback, DisconnectCallback {
     private static final LambdaLogger log = getLogger(P2PManagementWindow.class);
 
-    private final StorageProviderFactory storageProviderFactory;
-    private final Preferences preferences;
     private final WindowBasedTextGUI gui;
     private final ConnectionMessageMonitor monitor = new ConnectionMessageMonitor();
     private final PeerDetailWindow peerDetailWindow;
+    private final BelaContext belaContext;
     Map<Capability, Counter> counters = new HashMap<>();
     Counter connect = new Counter("connect");
     Counter disconnect = new Counter("disconnect");
     Map<DisconnectMessage.DisconnectReason, Counter> disconects = new ConcurrentHashMap<>();
     Panel rightCounters = new Panel();
-    BelaContext belaContext;
 
-    public P2PManagementWindow(final WindowBasedTextGUI gui, final StorageProviderFactory storageProviderFactory, final Preferences preferences) {
+    public P2PManagementWindow(final WindowBasedTextGUI gui, final BelaContext belaContext) {
         this.gui = gui;
-        this.storageProviderFactory = storageProviderFactory;
-        this.preferences = preferences;
-        belaContext = new MainNetContext(storageProviderFactory);
-        peerDetailWindow = new PeerDetailWindow(gui);
+        this.belaContext = belaContext;
+        this.peerDetailWindow = new PeerDetailWindow(gui);
     }
 
 

--- a/src/main/java/org/hyperledger/bela/windows/RocksDBViewer.java
+++ b/src/main/java/org/hyperledger/bela/windows/RocksDBViewer.java
@@ -12,9 +12,9 @@ import com.googlecode.lanterna.gui2.dialogs.MessageDialogBuilder;
 import com.googlecode.lanterna.gui2.dialogs.MessageDialogButton;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.bela.components.KeyControls;
+import org.hyperledger.bela.context.BelaContext;
 import org.hyperledger.bela.dialogs.BelaDialog;
 import org.hyperledger.bela.model.KeyValueConstants;
-import org.hyperledger.bela.utils.StorageProviderFactory;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
@@ -37,13 +37,13 @@ public class RocksDBViewer extends AbstractBelaWindow {
     private final ComboBox<KeyValueConstants> kvConstantsCombo = new ComboBox<>(KeyValueConstants.values());;
     private final TextBox keyBox = new TextBox(new TerminalSize(80, 1));
     private final TextBox valueBox = new TextBox(new TerminalSize(80, 25));
-    private final StorageProviderFactory storageProviderFactory;
     private final WindowBasedTextGUI gui;
+    private final BelaContext belaContext;
 
-    public RocksDBViewer(final WindowBasedTextGUI gui, final StorageProviderFactory storageProviderFactory) {
+    public RocksDBViewer(final WindowBasedTextGUI gui, final BelaContext belaContext) {
         this.gui = gui;
 
-        this.storageProviderFactory = storageProviderFactory;
+        this.belaContext = belaContext;
         keyBox.setValidationPattern(HEX_ONLY);
         valueBox.setValidationPattern(HEX_AND_WRAP_ONLY);
         kvConstantsCombo.addListener((selected, previous, changedByUser) -> {
@@ -101,7 +101,7 @@ public class RocksDBViewer extends AbstractBelaWindow {
 
     private void search() {
         try {
-            final StorageProvider provider = storageProviderFactory.createProvider();
+            final StorageProvider provider = belaContext.getProvider();
             final KeyValueStorage storageBySegmentIdentifier = provider.getStorageBySegmentIdentifier(identifierCombo.getSelectedItem());
             final Optional<byte[]> value = storageBySegmentIdentifier.get(Bytes.fromHexString(keyBox.getText())
                     .toArrayUnsafe());
@@ -119,7 +119,7 @@ public class RocksDBViewer extends AbstractBelaWindow {
 
     private void update() {
         try {
-            final StorageProvider provider = storageProviderFactory.createProvider();
+            StorageProvider provider = belaContext.getProvider();
             final KeyValueStorage storageBySegmentIdentifier = provider.getStorageBySegmentIdentifier(identifierCombo.getSelectedItem());
             if (keyBox.getText().length() > 0) {
                 final Optional<byte[]> key = Optional.ofNullable(Bytes.fromHexString(keyBox.getText())
@@ -152,7 +152,7 @@ public class RocksDBViewer extends AbstractBelaWindow {
 
     private void delete() {
         try {
-            final StorageProvider provider = storageProviderFactory.createProvider();
+            final StorageProvider provider = belaContext.getProvider();
             final KeyValueStorage storageBySegmentIdentifier = provider.getStorageBySegmentIdentifier(identifierCombo.getSelectedItem());
             final boolean deleted = storageBySegmentIdentifier.tryDelete(Bytes.fromHexString(keyBox.getText())
                 .toArrayUnsafe());


### PR DESCRIPTION
Currently Bela won't load most views due to a dependency on the Bonsai column families. This is a fairly naive fix to limit the scope to Bonsai when BONSAI is detected in the database. In FOREST mode, some functionality may still not work, but at least it loads the views now.

1. Only load Bonsai-specific menu items is database is BONSAI
2. Refactor to use BelaContext instead of StorageProviderFactory in most places
3. BelaContext now shares the DataStorageFormat and we guard the creation of the BonsaiWorldStateArchive - it is just null for FOREST, however I don't think it is used until we start using the TransactionTraceBrowser.
